### PR TITLE
兼容PHP 7.2

### DIFF
--- a/components/WechatComponent.php
+++ b/components/WechatComponent.php
@@ -1,13 +1,13 @@
 <?php
 namespace callmez\wechat\sdk\components;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * 微信
  * @package callmez\wechat\sdk\components
  */
-class WechatComponent extends Object
+class WechatComponent extends BaseObject
 {
     /**
      * @var BaseWechat


### PR DESCRIPTION
默认Object类名已经在PHP7.2中作为系统保留，使用yii新版本的BaseObject类即可兼容。